### PR TITLE
Langchain upgrade

### DIFF
--- a/src/ragbuilder/eval.py
+++ b/src/ragbuilder/eval.py
@@ -52,6 +52,7 @@ OPENAI_PRICING = {
     "gpt-3.5-turbo": {"input": 0.0015, "output": 0.002}, # gpt-3.5-turbo still defaults to gpt-3.5-turbo-0613
     "gpt-3.5-turbo-16k": {"input": 0.003, "output": 0.004},
     "gpt-4o": {"input": 0.005, "output": 0.015},
+    "gpt-4o-mini": {"input": 0.00015, "output": 0.0006},
     "gpt-4": {"input": 0.03, "output": 0.06},
     "gpt-4-turbo": {"input": 0.01, "output": 0.03},
     "gpt-4-32k": {"input": 0.06, "output": 0.12},

--- a/src/ragbuilder/executor.py
+++ b/src/ragbuilder/executor.py
@@ -33,7 +33,7 @@ RUN_CONFIG_MAX_WAIT = int(os.getenv('RUN_CONFIG_MAX_WAIT', '180'))
 RUN_CONFIG_MAX_RETRIES = int(os.getenv('RUN_CONFIG_MAX_RETRIES', '10'))
 RUN_CONFIG_IS_ASYNC = os.getenv('RUN_CONFIG_IS_ASYNC', 'true').lower() == 'true'
 chat_model = ChatOpenAI(
-    model="gpt-3.5-turbo-0125", 
+    model="gpt-4o-mini", 
     temperature=0.2,
     verbose=True
 )
@@ -53,7 +53,7 @@ PGVECTOR_CONNECTION_STRING = os.getenv("PGVECTOR_CONNECTION_STRING")
 import dotenv
 from langchain_community.document_loaders import *
 from langchain_text_splitters import *
-from langchain.retrievers import *
+# from langchain.retrievers import *
 from langchain.retrievers.document_compressors import *
 from langchain_community.document_transformers import *
 from langchain.retrievers.multi_query import *

--- a/src/ragbuilder/executor.py
+++ b/src/ragbuilder/executor.py
@@ -53,7 +53,19 @@ PGVECTOR_CONNECTION_STRING = os.getenv("PGVECTOR_CONNECTION_STRING")
 import dotenv
 from langchain_community.document_loaders import *
 from langchain_text_splitters import *
-# from langchain.retrievers import *
+from langchain_community.retrievers import AmazonKendraRetriever
+from langchain.retrievers import (
+    ContextualCompressionRetriever,
+    EnsembleRetriever,
+    MergerRetriever,
+    MultiQueryRetriever,
+    MultiVectorRetriever,
+    ParentDocumentRetriever,
+    RePhraseQueryRetriever,
+    SelfQueryRetriever,
+    TimeWeightedVectorStoreRetriever
+)
+
 from langchain.retrievers.document_compressors import *
 from langchain_community.document_transformers import *
 from langchain.retrievers.multi_query import *

--- a/src/ragbuilder/langchain_module/rag/test_codegen.py
+++ b/src/ragbuilder/langchain_module/rag/test_codegen.py
@@ -25,7 +25,7 @@ def rag_pipeline():
 
 
 
-        from langchain.retrievers import  BM25Retriever
+        from langchain_community.retrievers import  BM25Retriever
 
         from langchain.retrievers import ContextualCompressionRetriever
 

--- a/src/ragbuilder/langchain_module/retriever/retriever.py
+++ b/src/ragbuilder/langchain_module/retriever/retriever.py
@@ -9,11 +9,9 @@ from langchain.retrievers.document_compressors import CrossEncoderReranker
 from langchain_community.cross_encoders import HuggingFaceCrossEncoder
 
 from langchain.retrievers.multi_query import MultiQueryRetriever
-from langchain.retrievers import (
-    ContextualCompressionRetriever,
-    ParentDocumentRetriever,
-    BM25Retriever
-)
+from langchain.retrievers import ContextualCompressionRetriever, ParentDocumentRetriever
+from langchain_community.retrievers import BM25Retriever
+
 from langchain.storage import InMemoryStore
 from langchain.retrievers.document_compressors import *
 
@@ -81,7 +79,7 @@ from langchain.storage import InMemoryStore"""
     elif retriever_type == "bm25Retriever":
         logger.info("BM25Retriever Retriever Invoked")
         code_string= f"""retriever=BM25Retriever.from_documents(docs)"""
-        import_string = f"""from langchain.retrievers import  BM25Retriever"""
+        import_string = f"""from langchain_community.retrievers import  BM25Retriever"""
         return {'code_string':code_string,'import_string':import_string}
 
     else:


### PR DESCRIPTION
Get rid of Langchain deprecation warnings by migrating to langchain_community.retrievers for some of the retrievers.